### PR TITLE
Return nil in load_all if a save doesn't exist

### DIFF
--- a/lady.lua
+++ b/lady.lua
@@ -539,9 +539,13 @@ end
 local load_mt = {__index = registered_things_by_name}
 function M.load_all(savename)
 	local contents = love.filesystem.read(savename)
-	local s = loadstring(contents)
-	setfenv(s, setmetatable({_L = loadstring, _S = setmetatable, _M = getmetatable, love = love}, load_mt))
-	return s()
+	if contents then
+		local s = loadstring(contents)
+		setfenv(s, setmetatable({_L = loadstring, _S = setmetatable, _M = getmetatable, love = love}, load_mt))
+		return s()
+	else
+		return nil
+	end
 end
 
 return M


### PR DESCRIPTION
If I try to load save which doesn't exist I get a system error. I haven't found any way to handle this error. This PR aims to fix it.
